### PR TITLE
added additional routes for events

### DIFF
--- a/src/main/java/com/keyin/rest/event/EventController.java
+++ b/src/main/java/com/keyin/rest/event/EventController.java
@@ -20,7 +20,16 @@ public class EventController {
     }
 
     @GetMapping
-    public List<Event> list() {
+    public List<Event> list(
+            @RequestParam(required = false) Long venueId,
+            @RequestParam(required = false) Long organizerId
+    ) {
+        if (venueId != null) {
+            return service.getEventsByVenue(venueId);
+        }
+        if (organizerId != null) {
+            return service.getEventsByOrganizer(organizerId);
+        }
         return service.getAll();
     }
 

--- a/src/main/java/com/keyin/rest/event/EventRepository.java
+++ b/src/main/java/com/keyin/rest/event/EventRepository.java
@@ -2,8 +2,10 @@ package com.keyin.rest.event;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    // No additional methods needed for basic CRUD operations
-    // JpaRepository provides methods like findAll, findById, save, deleteById, etc.
+    List<Event> findByVenueId(Long venueId);
+    List<Event> findByOrganizerId(Long organizerId);
 }

--- a/src/main/java/com/keyin/rest/event/EventService.java
+++ b/src/main/java/com/keyin/rest/event/EventService.java
@@ -27,6 +27,14 @@ public class EventService {
                         HttpStatus.NOT_FOUND, "Event not found with id " + id));
     }
 
+    public List<Event> getEventsByVenue(Long venueId) {
+        return repo.findByVenueId(venueId);
+    }
+
+    public List<Event> getEventsByOrganizer(Long organizerId) {
+        return repo.findByOrganizerId(organizerId);
+    }
+
     public Event create(Event event) {
         return repo.save(event);
     }


### PR DESCRIPTION
This pull request introduces functionality to filter events by `venueId` and `organizerId` in the `EventController`. It adds corresponding methods in the `EventService` and `EventRepository` to support these filters.

### Enhancements to event filtering:

* **Controller-level filtering**: Updated the `list` method in `EventController` to accept optional `venueId` and `organizerId` query parameters. Based on these parameters, the method now fetches events by venue, organizer, or returns all events if no filters are provided. (`src/main/java/com/keyin/rest/event/EventController.java`, [src/main/java/com/keyin/rest/event/EventController.javaL23-R32](diffhunk://#diff-9064fc2ee30a6be52388f3bb72381b12eb86fcaeb001e833b2224575cb4e3703L23-R32))

* **Service-level support**: Added `getEventsByVenue` and `getEventsByOrganizer` methods in `EventService` to handle the logic for fetching filtered events. These methods delegate the queries to the repository. (`src/main/java/com/keyin/rest/event/EventService.java`, [src/main/java/com/keyin/rest/event/EventService.javaR30-R37](diffhunk://#diff-030e0c92bdd9865be9dc178b95b69060de22791e75d52b3e5e4636f143630895R30-R37))

* **Repository-level queries**: Introduced `findByVenueId` and `findByOrganizerId` methods in `EventRepository` to enable database queries for filtering events based on venue and organizer. (`src/main/java/com/keyin/rest/event/EventRepository.java`, [src/main/java/com/keyin/rest/event/EventRepository.javaR5-R10](diffhunk://#diff-a7c27f23ea887c1b73bd18fdbd1dd4654f64964487f79327e52ce2b0192d727fR5-R10))